### PR TITLE
Archive command bug-fix

### DIFF
--- a/contents/lxc/migration.md
+++ b/contents/lxc/migration.md
@@ -14,7 +14,7 @@ Move or backup LXC containers:
 2. Archive the container's _rootfs_ & _config_:
 
 	```
-	$ tar --numeric-owner -czvf <container-name>.tar.gz -C </path/to/container>
+	$ tar --numeric-owner -czvf <container-name>.tar.gz -C </path/to/containers-dir> <container>
 	```
 
 	> `--numeric-owner` preserving user / group ownerships _numerically_.


### PR DESCRIPTION
The `-C` flag should be followed by the directory _holding_ the containers not including the container itself)! The container itself is specified by a separate(d by space) argument.

I'm not sure if the same holds for the extraction.